### PR TITLE
Implement global rounding and recurring licenses

### DIFF
--- a/src/components/NoveltyManagement.tsx
+++ b/src/components/NoveltyManagement.tsx
@@ -108,26 +108,48 @@ export const NoveltyManagement: React.FC<NoveltyManagementProps> = ({
     }
   ];
 
-  // Get employees with and without novelties for selected month
-  const employeesWithNovelties = novelties
-    .filter(novelty => novelty.date.startsWith(selectedMonth))
-    .map(novelty => novelty.employeeId);
-  
+  // Build novelties list for the selected month, including recurring licenses
+  const displayedNovelties: Novelty[] = novelties.reduce((acc: Novelty[], n) => {
+    const noveltyMonth = n.date.slice(0, 7);
+
+    if (n.isRecurring && n.startMonth && n.startMonth <= selectedMonth) {
+      const existsForThisMonth = novelties.some(other =>
+        other.employeeId === n.employeeId &&
+        other.type === n.type &&
+        other.date.slice(0, 7) === selectedMonth
+      );
+
+      if (existsForThisMonth) {
+        if (noveltyMonth === selectedMonth) acc.push(n);
+      } else {
+        acc.push({
+          ...n,
+          id: `recurring-${n.id}-${selectedMonth}`,
+          date: `${selectedMonth}-01`,
+          description: `${n.description} (Licencia recurrente desde ${n.startMonth})`
+        });
+      }
+    } else if (noveltyMonth === selectedMonth) {
+      acc.push(n);
+    }
+    return acc;
+  }, [] as Novelty[]);
+
+  const employeesWithNovelties = Array.from(new Set(displayedNovelties.map(n => n.employeeId)));
+
   const employeesWithoutNovelties = employees
     .filter(emp => !employeesWithNovelties.includes(emp.id))
     .sort((a, b) => a.name.localeCompare(b.name));
-  
+
   const employeesWithNoveltiesData = employees
     .filter(emp => employeesWithNovelties.includes(emp.id))
     .sort((a, b) => a.name.localeCompare(b.name));
 
-  const noveltiesByEmployee = novelties
-    .filter(novelty => novelty.date.startsWith(selectedMonth))
-    .reduce<Record<string, Novelty[]>>((acc, novelty) => {
-      if (!acc[novelty.employeeId]) acc[novelty.employeeId] = [];
-      acc[novelty.employeeId].push(novelty);
-      return acc;
-    }, {});
+  const noveltiesByEmployee = displayedNovelties.reduce<Record<string, Novelty[]>>((acc, novelty) => {
+    if (!acc[novelty.employeeId]) acc[novelty.employeeId] = [];
+    acc[novelty.employeeId].push(novelty);
+    return acc;
+  }, {});
 
   const getNoveltyTypeInfo = (type: Novelty['type']) => {
     for (const category of noveltyCategories) {
@@ -250,7 +272,7 @@ export const NoveltyManagement: React.FC<NoveltyManagementProps> = ({
     setFormData({
       employeeId,
       type: (category?.types[0].value || 'ABSENCE') as Novelty['type'],
-      date: new Date().toISOString().slice(0, 10),
+      date: `${selectedMonth}-01`,
       description: '',
       value: '1',
     });
@@ -326,7 +348,7 @@ export const NoveltyManagement: React.FC<NoveltyManagementProps> = ({
             employeeId,
             employeeName: employee.name,
             type: data.type,
-            date: new Date().toISOString().slice(0, 10),
+            date: `${selectedMonth}-01`,
             description: data.description || '',
             discountDays: typeInfo.unitType === 'DAYS' && ['ABSENCE', 'LATE', 'EARLY_LEAVE', 'MEDICAL_LEAVE', 'VACATION'].includes(data.type) ? value : 0,
             bonusAmount: typeInfo.unitType === 'MONEY' ? value : 0,

--- a/src/components/PayrollCalculator.tsx
+++ b/src/components/PayrollCalculator.tsx
@@ -2,21 +2,10 @@ import React, { useState } from 'react';
 import { Calculator, Download, AlertCircle, TrendingUp, CreditCard, ZoomIn, ZoomOut } from 'lucide-react';
 import { Employee, Novelty, PayrollCalculation, AdvancePayment, DeductionRates, MINIMUM_SALARY_COLOMBIA, TRANSPORT_ALLOWANCE } from '../types';
 import { getDaysInMonth, formatMonthYear, parseMonthString, isEmployeeActiveInMonth } from '../utils/dateUtils';
+import { roundToNearest500Or1000 } from '../utils/financeUtils';
 
 const PAYROLL_DAYS = 30;
 
-// Function to round to nearest 500 or 1000
-const roundToNearest500Or1000 = (amount: number): number => {
-  const remainder = amount % 1000;
-  
-  if (remainder <= 500) {
-    // Round down to nearest 1000, then add 500 if remainder > 0
-    return Math.floor(amount / 1000) * 1000 + (remainder > 0 ? 500 : 0);
-  } else {
-    // Round up to next 1000
-    return Math.ceil(amount / 1000) * 1000;
-  }
-};
 
 interface PayrollCalculatorProps {
   employees: Employee[];

--- a/src/utils/financeUtils.ts
+++ b/src/utils/financeUtils.ts
@@ -1,0 +1,8 @@
+export const roundToNearest500Or1000 = (amount: number): number => {
+  const remainder = amount % 1000;
+  if (remainder <= 500) {
+    return Math.floor(amount / 1000) * 1000 + (remainder > 0 ? 500 : 0);
+  } else {
+    return Math.ceil(amount / 1000) * 1000;
+  }
+};


### PR DESCRIPTION
## Summary
- centralize rounding logic in `financeUtils`
- use rounding utils in payroll calculator
- keep recurring license novelties visible for future months
- ensure new novelties default to the selected month

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687410888c548324a4d05c1fc6a9a79a