### PR TITLE
Fix advance payslips and employee start date

### DIFF
--- a/src/components/EmployeeManagement.tsx
+++ b/src/components/EmployeeManagement.tsx
@@ -70,7 +70,7 @@ export const EmployeeManagement: React.FC<EmployeeManagementProps> = ({ employee
       dateOfBirth: formData.dateOfBirth,
       salary: parseFloat(formData.salary),
       isPensioned: formData.isPensioned,
-      workedDays: editingEmployee ? editingEmployee.workedDays : calculateWorkedDays(formData.createdDate),
+      workedDays: calculateWorkedDays(formData.createdDate),
       createdDate: formData.createdDate,
     };
 
@@ -253,20 +253,18 @@ export const EmployeeManagement: React.FC<EmployeeManagementProps> = ({ employee
                   </label>
                 </div>
                 
-                {!editingEmployee && (
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                      Fecha de Ingreso
-                    </label>
-                    <input
-                      type="date"
-                      value={formData.createdDate}
-                      onChange={(e) => setFormData({ ...formData, createdDate: e.target.value })}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                      required
-                    />
-                  </div>
-                )}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Fecha de Ingreso
+                  </label>
+                  <input
+                    type="date"
+                    value={formData.createdDate}
+                    onChange={(e) => setFormData({ ...formData, createdDate: e.target.value })}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    required
+                  />
+                </div>
               </div>
               
               <div className="flex justify-end space-x-3 pt-4">

--- a/src/components/PayrollPreview.tsx
+++ b/src/components/PayrollPreview.tsx
@@ -1,18 +1,28 @@
 import React from 'react';
 import { FileText, User, Calendar, DollarSign, AlertCircle, History, Download, TrendingUp } from 'lucide-react';
-import { PayrollCalculation } from '../types';
+import { PayrollCalculation, AdvancePayment } from '../types';
 import { formatMonthYear } from '../utils/dateUtils';
 
 interface PayrollPreviewProps {
   payrollCalculations: PayrollCalculation[];
-  advances: any[];
+  advances: AdvancePayment[];
+}
+
+interface HistoricalSummary {
+  month: string;
+  calculations: PayrollCalculation[];
+  totalNet: number;
+  totalDeductions: number;
+  totalBonuses: number;
+  totalTransport: number;
+  employeeCount: number;
 }
 
 export const PayrollPreview: React.FC<PayrollPreviewProps> = ({ payrollCalculations, advances }) => {
   const [showHistory, setShowHistory] = React.useState(false);
   const [startMonth, setStartMonth] = React.useState(new Date().toISOString().slice(0, 7));
   const [endMonth, setEndMonth] = React.useState(new Date().toISOString().slice(0, 7));
-  const [historicalData, setHistoricalData] = React.useState<any[]>([]);
+  const [historicalData, setHistoricalData] = React.useState<HistoricalSummary[]>([]);
 
   // Get all stored payroll calculations from localStorage
   const getAllStoredPayrolls = () => {


### PR DESCRIPTION
## Summary
- allow toggling the payslip view in advance management
- export advance payslips to TXT
- allow editing employee start date and recalculate days
- define proper types in payroll preview

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68857ed9f3308324a88909ca1463ebe7