### PR TITLE
Fix recurring license duplication

### DIFF
--- a/src/components/PayrollCalculator.tsx
+++ b/src/components/PayrollCalculator.tsx
@@ -41,18 +41,10 @@ export const PayrollCalculator: React.FC<PayrollCalculatorProps> = ({
       // Get all novelties for this employee
       const allEmployeeNovelties = novelties.filter(n => n.employeeId === employee.id);
       
-      // Get novelties that apply to the selected month
-      const monthlyNovelties = allEmployeeNovelties.filter(n => {
-        const noveltyMonth = n.date.slice(0, 7);
-        
-        // If it's a recurring license, check if it should apply to this month
-        if (n.isRecurring && n.startMonth) {
-          return n.startMonth <= selectedMonth;
-        }
-        
-        // For non-recurring novelties, only include if they're for this specific month
-        return noveltyMonth === selectedMonth;
-      });
+      // Get novelties that are explicitly registered for the selected month
+      const monthlyNovelties = allEmployeeNovelties.filter(n =>
+        n.date.slice(0, 7) === selectedMonth
+      );
       
       // For recurring licenses, create a virtual novelty for this month if it doesn't exist
       const recurringLicenses = allEmployeeNovelties.filter(n => 


### PR DESCRIPTION
## Summary
- compute monthly novelties only from the chosen month
- keep creating virtual entries for active study licenses

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68858204039c83249bbd2457a56f97c7