### PR TITLE
Handle hire date in monthly sections

### DIFF
--- a/src/components/AdvanceManagement.tsx
+++ b/src/components/AdvanceManagement.tsx
@@ -42,15 +42,19 @@ export const AdvanceManagement: React.FC<AdvanceManagementProps> = ({
   });
 
   // Get employees with and without advances for selected month
+  const employeesForMonth = employees.filter(emp =>
+    !emp.createdDate || emp.createdDate.slice(0, 7) <= selectedMonth
+  );
+
   const employeesWithAdvances = advances
     .filter(advance => advance.month === selectedMonth)
     .map(advance => advance.employeeId);
-  
-  const employeesWithoutAdvances = employees
+
+  const employeesWithoutAdvances = employeesForMonth
     .filter(emp => !employeesWithAdvances.includes(emp.id))
     .sort((a, b) => a.name.localeCompare(b.name));
-  
-  const employeesWithAdvancesData = employees
+
+  const employeesWithAdvancesData = employeesForMonth
     .filter(emp => employeesWithAdvances.includes(emp.id))
     .sort((a, b) => a.name.localeCompare(b.name));
 
@@ -179,7 +183,9 @@ export const AdvanceManagement: React.FC<AdvanceManagementProps> = ({
     txtContent += `${'='.repeat(50)}\n\n`;
 
     const advancesForMonth = advances
-      .filter(a => a.month === selectedMonth)
+      .filter(a => a.month === selectedMonth &&
+        (!employees.find(emp => emp.id === a.employeeId)?.createdDate ||
+         employees.find(emp => emp.id === a.employeeId)!.createdDate!.slice(0,7) <= selectedMonth))
       .sort((a, b) => a.employeeName.localeCompare(b.employeeName));
 
     advancesForMonth.forEach((adv, index) => {
@@ -226,7 +232,11 @@ export const AdvanceManagement: React.FC<AdvanceManagementProps> = ({
   };
 
   const totalAdvances = advances
-    .filter(advance => advance.month === selectedMonth)
+    .filter(advance =>
+      advance.month === selectedMonth &&
+      (!employees.find(emp => emp.id === advance.employeeId)?.createdDate ||
+       employees.find(emp => emp.id === advance.employeeId)!.createdDate!.slice(0, 7) <= selectedMonth)
+    )
     .reduce((sum, advance) => sum + advance.amount, 0);
 
   return (
@@ -275,7 +285,12 @@ export const AdvanceManagement: React.FC<AdvanceManagementProps> = ({
       </div>
 
       {/* Payslips Section */}
-      {showPayslips && advances.filter(a => a.month === selectedMonth).length > 0 && (
+      {showPayslips &&
+        advances.filter(a =>
+          a.month === selectedMonth &&
+          (!employees.find(emp => emp.id === a.employeeId)?.createdDate ||
+           employees.find(emp => emp.id === a.employeeId)!.createdDate!.slice(0, 7) <= selectedMonth)
+        ).length > 0 && (
         <div className="bg-white rounded-lg shadow-md border border-gray-200">
           <div className="px-6 py-4 border-b border-gray-200 bg-indigo-50">
             <div className="flex justify-between items-center">
@@ -295,7 +310,11 @@ export const AdvanceManagement: React.FC<AdvanceManagementProps> = ({
           <div className="p-6">
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {advances
-                .filter(advance => advance.month === selectedMonth)
+                .filter(advance =>
+                  advance.month === selectedMonth &&
+                  (!employees.find(emp => emp.id === advance.employeeId)?.createdDate ||
+                   employees.find(emp => emp.id === advance.employeeId)!.createdDate!.slice(0, 7) <= selectedMonth)
+                )
                 .sort((a, b) => a.employeeName.localeCompare(b.employeeName))
                 .map((advance) => {
                   const employee = employees.find(emp => emp.id === advance.employeeId);
@@ -533,7 +552,11 @@ export const AdvanceManagement: React.FC<AdvanceManagementProps> = ({
               </thead>
               <tbody className="bg-white divide-y divide-gray-200">
                 {advances
-                  .filter(advance => advance.month === selectedMonth)
+                  .filter(advance =>
+                    advance.month === selectedMonth &&
+                    (!employees.find(emp => emp.id === advance.employeeId)?.createdDate ||
+                     employees.find(emp => emp.id === advance.employeeId)!.createdDate!.slice(0, 7) <= selectedMonth)
+                  )
                   .sort((a, b) => a.employeeName.localeCompare(b.employeeName))
                   .map((advance) => (
                     <tr key={advance.id} className="bg-green-25 hover:bg-green-50">
@@ -626,7 +649,7 @@ export const AdvanceManagement: React.FC<AdvanceManagementProps> = ({
                   required
                 >
                   <option value="">Seleccionar empleado</option>
-                  {employees.map((employee) => (
+                  {employeesForMonth.map((employee) => (
                     <option key={employee.id} value={employee.id}>
                       {employee.name}
                     </option>

--- a/src/components/EmployeeManagement.tsx
+++ b/src/components/EmployeeManagement.tsx
@@ -334,7 +334,7 @@ export const EmployeeManagement: React.FC<EmployeeManagementProps> = ({ employee
               </div>
               <div className="pt-2 border-t">
                 <p className="text-gray-600">Salario: <span className="font-semibold">${employee.salary.toLocaleString()}</span></p>
-                <p className="text-gray-600">Días trabajados totales: <span className="font-semibold">{employee.workedDays}</span></p>
+                <p className="text-gray-600">Fecha de ingreso: <span className="font-semibold">{employee.createdDate ? new Date(employee.createdDate).toLocaleDateString() : 'N/A'}</span></p>
                 {employee.isPensioned && (
                   <p className="text-blue-600 text-sm font-medium">✓ Empleado pensionado</p>
                 )}

--- a/src/components/NoveltyManagement.tsx
+++ b/src/components/NoveltyManagement.tsx
@@ -111,6 +111,10 @@ export const NoveltyManagement: React.FC<NoveltyManagementProps> = ({
   // Build novelties list for the selected month, including recurring licenses
   const displayedNovelties: Novelty[] = novelties.reduce((acc: Novelty[], n) => {
     const noveltyMonth = n.date.slice(0, 7);
+    const employee = employees.find(emp => emp.id === n.employeeId);
+    if (employee && employee.createdDate && employee.createdDate.slice(0, 7) > selectedMonth) {
+      return acc; // ignore novelties before employee's start date
+    }
 
     if (n.isRecurring && n.startMonth && n.startMonth <= selectedMonth) {
       const existsForThisMonth = novelties.some(other =>
@@ -135,13 +139,17 @@ export const NoveltyManagement: React.FC<NoveltyManagementProps> = ({
     return acc;
   }, [] as Novelty[]);
 
+  const employeesForMonth = employees.filter(emp =>
+    !emp.createdDate || emp.createdDate.slice(0, 7) <= selectedMonth
+  );
+
   const employeesWithNovelties = Array.from(new Set(displayedNovelties.map(n => n.employeeId)));
 
-  const employeesWithoutNovelties = employees
+  const employeesWithoutNovelties = employeesForMonth
     .filter(emp => !employeesWithNovelties.includes(emp.id))
     .sort((a, b) => a.name.localeCompare(b.name));
 
-  const employeesWithNoveltiesData = employees
+  const employeesWithNoveltiesData = employeesForMonth
     .filter(emp => employeesWithNovelties.includes(emp.id))
     .sort((a, b) => a.name.localeCompare(b.name));
 
@@ -705,7 +713,7 @@ export const NoveltyManagement: React.FC<NoveltyManagementProps> = ({
                   required
                 >
                   <option value="">Seleccionar empleado</option>
-                  {employees.map((employee) => (
+                  {employeesForMonth.map((employee) => (
                     <option key={employee.id} value={employee.id}>
                       {employee.name}
                     </option>


### PR DESCRIPTION
## Summary
- display employee hire date instead of total days worked
- restrict novelty view to employees hired by selected month
- filter out novelties that precede an employee's start date
- limit quincena advance features to employees hired in the month

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887999328b8832480a33bd2508f480d