### PR TITLE
Add monthly payroll storage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,7 @@ function App() {
   const [novelties, setNovelties]               = useLocalStorage<Novelty[]>           ('novelties',         []);
   const [advances, setAdvances]                 = useLocalStorage<AdvancePayment[]>    ('advances',          []);
   const [payrollCalculations, setPayroll]       = useLocalStorage<PayrollCalculation[]>('payrollCalculations', []);
+  const [monthlyPayrolls, setMonthlyPayrolls]   = useLocalStorage<Record<string, PayrollCalculation[]>>('monthlyPayrolls', {});
   const [deductionRates, setDeductionRates]     = useLocalStorage<DeductionRates>      ('deductionRates',    DEFAULT_DEDUCTION_RATES);
 
   // Migration function to add isPensioned field to existing employees
@@ -156,10 +157,18 @@ function App() {
             deductionRates={deductionRates}
             payrollCalculations={payrollCalculations}
             setPayrollCalculations={setPayroll}
+            monthlyPayrolls={monthlyPayrolls}
+            setMonthlyPayrolls={setMonthlyPayrolls}
           />
         );
       case 'preview':
-        return <PayrollPreview payrollCalculations={payrollCalculations} advances={advances} />;
+        return (
+          <PayrollPreview
+            payrollCalculations={payrollCalculations}
+            advances={advances}
+            monthlyPayrolls={monthlyPayrolls}
+          />
+        );
       case 'settings':
         return (
           <SettingsManagement

--- a/src/components/PayrollCalculator.tsx
+++ b/src/components/PayrollCalculator.tsx
@@ -14,6 +14,8 @@ interface PayrollCalculatorProps {
   deductionRates: DeductionRates;
   setPayrollCalculations: (calculations: PayrollCalculation[]) => void;
   payrollCalculations: PayrollCalculation[];
+  monthlyPayrolls: Record<string, PayrollCalculation[]>;
+  setMonthlyPayrolls: (history: Record<string, PayrollCalculation[]>) => void;
 }
 
 export const PayrollCalculator: React.FC<PayrollCalculatorProps> = ({ 
@@ -22,12 +24,19 @@ export const PayrollCalculator: React.FC<PayrollCalculatorProps> = ({
   advances,
   deductionRates,
   setPayrollCalculations,
-  payrollCalculations 
+  payrollCalculations,
+  monthlyPayrolls,
+  setMonthlyPayrolls
 }) => {
   const [selectedMonth, setSelectedMonth] = useState(new Date().toISOString().slice(0, 7));
   const [selectedDate, setSelectedDate] = useState(new Date().toISOString().slice(0, 10));
   const [isCalculating, setIsCalculating] = useState(false);
   const [tableZoom, setTableZoom] = useState(100);
+
+  React.useEffect(() => {
+    const stored = monthlyPayrolls[selectedMonth] || [];
+    setPayrollCalculations(stored);
+  }, [selectedMonth, monthlyPayrolls, setPayrollCalculations]);
 
   const calculatePayroll = () => {
     setIsCalculating(true);
@@ -208,6 +217,7 @@ export const PayrollCalculator: React.FC<PayrollCalculatorProps> = ({
     });
     
     setPayrollCalculations(calculations);
+    setMonthlyPayrolls(prev => ({ ...prev, [selectedMonth]: calculations }));
     setIsCalculating(false);
   };
 

--- a/src/components/PayrollPreview.tsx
+++ b/src/components/PayrollPreview.tsx
@@ -6,6 +6,7 @@ import { formatMonthYear } from '../utils/dateUtils';
 interface PayrollPreviewProps {
   payrollCalculations: PayrollCalculation[];
   advances: AdvancePayment[];
+  monthlyPayrolls: Record<string, PayrollCalculation[]>;
 }
 
 interface HistoricalSummary {
@@ -18,41 +19,24 @@ interface HistoricalSummary {
   employeeCount: number;
 }
 
-export const PayrollPreview: React.FC<PayrollPreviewProps> = ({ payrollCalculations, advances }) => {
+export const PayrollPreview: React.FC<PayrollPreviewProps> = ({ payrollCalculations, advances, monthlyPayrolls }) => {
   const [showHistory, setShowHistory] = React.useState(false);
   const [showPayslips, setShowPayslips] = React.useState(false);
   const [startMonth, setStartMonth] = React.useState(new Date().toISOString().slice(0, 7));
   const [endMonth, setEndMonth] = React.useState(new Date().toISOString().slice(0, 7));
   const [historicalData, setHistoricalData] = React.useState<HistoricalSummary[]>([]);
 
-  // Get all stored payroll calculations from localStorage
-  const getAllStoredPayrolls = () => {
-    try {
-      const stored = localStorage.getItem('payrollCalculations');
-      return stored ? JSON.parse(stored) : [];
-    } catch {
-      return [];
-    }
-  };
-
   const generateHistoricalReport = () => {
-    const allPayrolls = getAllStoredPayrolls();
     const startDate = new Date(startMonth + '-01');
     const endDate = new Date(endMonth + '-01');
-    
+
     // Group payrolls by month and filter by date range
     const monthlyData: { [key: string]: PayrollCalculation[] } = {};
-    
-    allPayrolls.forEach((calc: PayrollCalculation) => {
-      // Try to determine the month from the calculation date or use current month as fallback
-      const calcMonth = calc.employee.createdDate?.slice(0, 7) || new Date().toISOString().slice(0, 7);
-      const calcDate = new Date(calcMonth + '-01');
-      
-      if (calcDate >= startDate && calcDate <= endDate) {
-        if (!monthlyData[calcMonth]) {
-          monthlyData[calcMonth] = [];
-        }
-        monthlyData[calcMonth].push(calc);
+
+    Object.entries(monthlyPayrolls).forEach(([month, calculations]) => {
+      const monthDate = new Date(month + '-01');
+      if (monthDate >= startDate && monthDate <= endDate) {
+        monthlyData[month] = calculations;
       }
     });
     


### PR DESCRIPTION
## Summary
- track payroll calculations per month via `monthlyPayrolls` state
- load saved calculations when switching months
- keep historical preview using stored payrolls

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887eb2f215083248376be5a9e704fc7