### PR TITLE
Add month selector for payslip preview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,8 +164,6 @@ function App() {
       case 'preview':
         return (
           <PayrollPreview
-            payrollCalculations={payrollCalculations}
-            advances={advances}
             monthlyPayrolls={monthlyPayrolls}
           />
         );


### PR DESCRIPTION
## Summary
- allow selecting a month when previewing payslips
- adapt preview totals to use the chosen month
- simplify `PayrollPreview` props

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887eed59e0c8324bf3fdbfef7ea0793